### PR TITLE
Don't exit when qpdf repairs the file successfully but displays warning

### DIFF
--- a/ocrmypdf/main.py
+++ b/ocrmypdf/main.py
@@ -356,14 +356,20 @@ def repair_pdf(
     try:
         out = check_output(args_qpdf, stderr=STDOUT, universal_newlines=True)
     except CalledProcessError as e:
+        exit_with_error = 1
         if e.returncode == 2:
             print("{0}: not a valid PDF, and could not repair it.".format(
                     options.input_file))
             print("Details:")
             print(e.output)
+        elif e.returncode == 3 and e.output.find("operation succeeded"):
+            exit_with_error = 0
+            out = e.output
+            print(e.output)
         else:
             print(e.output)
-        sys.exit(ExitCode.input_file)
+        if exit_with_error == 1:
+            sys.exit(ExitCode.input_file)
 
     log.debug(out)
 

--- a/ocrmypdf/main.py
+++ b/ocrmypdf/main.py
@@ -356,19 +356,19 @@ def repair_pdf(
     try:
         out = check_output(args_qpdf, stderr=STDOUT, universal_newlines=True)
     except CalledProcessError as e:
-        exit_with_error = 1
+        exit_with_error = True
         if e.returncode == 2:
             print("{0}: not a valid PDF, and could not repair it.".format(
                     options.input_file))
             print("Details:")
             print(e.output)
         elif e.returncode == 3 and e.output.find("operation succeeded"):
-            exit_with_error = 0
+            exit_with_error = False
             out = e.output
             print(e.output)
         else:
             print(e.output)
-        if exit_with_error == 1:
+        if exit_with_error:
             sys.exit(ExitCode.input_file)
 
     log.debug(out)


### PR DESCRIPTION
OCRmyPDF exits when a PDF file is a little bit broken but is successfully repaired by qpdf.  I think it should just display the warning and continue.

Here's a sample error display:
WARNING: /home/shemgp/Desktop/Rusli Heince - Clearance.pdf: reported number of objects (7) inconsistent with actual number of objects (8)
WARNING: /home/shemgp/Desktop/Rusli Heince - Clearance.pdf: file is damaged
WARNING: /home/shemgp/Desktop/Rusli Heince - Clearance.pdf (object 5 0, file position 446097): expected 5 0 obj
WARNING: /home/shemgp/Desktop/Rusli Heince - Clearance.pdf: Attempting to reconstruct cross-reference table
WARNING: /home/shemgp/Desktop/Rusli Heince - Clearance.pdf (object 2 0, file position 445846): stream keyword followed by carriage return only
WARNING: /home/shemgp/Desktop/Rusli Heince - Clearance.pdf (object 1 0, file position 176): stream keyword followed by carriage return only
qpdf: operation succeeded with warnings; resulting file may have some problems
