### PR TITLE
Adding explicit reference to help

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -251,9 +251,13 @@ languages can be requested.
 Support
 -------
 
-In case you detect an issue, please:
+Once ocrmypdf is installed, the built-in help which explains the command syntax and options can be accessed via
 
--  Check if your issue is already known
+   ocrmypdf --help
+
+If you detect an issue, please:
+
+-  Check whether your issue is already known
 -  If no problem report exists on github, please create one here:
    https://github.com/jbarlow83/OCRmyPDF/issues
 -  Describe your problem thoroughly


### PR DESCRIPTION
Just making explicit the way to get help on command syntax after I searched for and found it in #18.