### PR TITLE
pytest skipif for milk.pdf test

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -634,5 +634,7 @@ def test_masks(spoof_tesseract_noop):
     check_ocrmypdf('masks.pdf', 'test_masks.pdf', env=spoof_tesseract_noop)
 
 
+@pytest.mark.skipif(not os.path.isfile(_infile('milk.pdf')),
+                    reason="fair use restricted test resource does not exist")
 def test_linearized_pdf_and_indirect_object(spoof_tesseract_noop):
     check_ocrmypdf('milk.pdf', 'test_milk.pdf', env=spoof_tesseract_noop)


### PR DESCRIPTION
Skip the test if the fair use restricted milk.pdf is not present.

When #93 is resolved this could be generalised for all tests using restricted files that can be opted-out from.