### PR TITLE
Remove misplaced flags from re.sub() call

### DIFF
--- a/ocrmypdf/__main__.py
+++ b/ocrmypdf/__main__.py
@@ -420,7 +420,7 @@ def available_cpu_count():
 
 
 def cleanup_ruffus_error_message(msg):
-    msg = re.sub(r'\s+', r' ', msg, re.MULTILINE)
+    msg = re.sub(r'\s+', r' ', msg)
     msg = re.sub(r"\((.+?)\)", r'\1', msg)
     msg = msg.strip()
     return msg


### PR DESCRIPTION
The 4th argument of `re.sub()` is maximum number of substitutions, not flags.
Moreover, `re.MULTILINE` affects only semantics of `^` and `$`, so it wouldn't have any effect on this regular expression.

Found using [pydiatra](https://github.com/jwilk/pydiatra).