### PR TITLE
added missing dependencies for cffi and Pillow when building for RaspberryPi 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,16 @@ MAINTAINER James R. Barlow <jim@purplerock.ca>
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   software-properties-common python-software-properties \
+    build-essential \
+    xvfb \
+    git wget python-virtualenv python-numpy python-scipy netpbm \
+    python-pyqt5 ghostscript libffi-dev libjpeg-turbo-progs \
+    python-dev python-setuptools \
+    python3-dev cmake  \
+    libtiff5-dev libjpeg8-dev zlib1g-dev \
+    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev \
+    python-tk python3-tk \
+    libharfbuzz-dev libfribidi-dev \
   python3-wheel \
   python3-reportlab \
   python3-venv \


### PR DESCRIPTION
I had problems with missing dependencies when building for RaspberryPi 3.
I've just copied all dependencies from https://github.com/python-pillow/docker-images/blob/master/ubuntu-xenial-amd64/Dockerfile.
There are maybe some which are not necessary.