### PR TITLE
Add option to explicitly add interword spaces to HOCR pdf-renderer

### DIFF
--- a/ocrmypdf/__main__.py
+++ b/ocrmypdf/__main__.py
@@ -304,6 +304,9 @@ advanced.add_argument(
 advanced.add_argument(
     '--user-patterns', metavar='FILE',
     help="Specify the location of the Tesseract user patterns file.")
+advanced.add_argument(
+    '--interword-spaces', action='store_true',
+    help="Add spaces between words with HOCR transformation.")
 
 debugging = parser.add_argument_group(
     "Debugging",
@@ -463,7 +466,11 @@ def check_options_advanced(options, log):
             "--pdfa-image-compression argument has no effect when "
             "--output-type is not 'pdfa', 'pdfa-1', or 'pdfa-2'"
         )
-
+    if options.interword_spaces and options.pdf_renderer != 'hocr':
+        log.warning(
+            "--interword-spaces argument has no effect when "
+            "--pdf-renderer is not 'hocr'"
+        )
 
 def check_options_metadata(options, log):
     import unicodedata

--- a/ocrmypdf/hocrtransform.py
+++ b/ocrmypdf/hocrtransform.py
@@ -137,7 +137,7 @@ class HocrTransform():
         return s
 
     def to_pdf(self, outFileName, imageFileName=None, showBoundingboxes=False,
-               fontname="Helvetica", invisibleText=False):
+               fontname="Helvetica", invisibleText=False, interwordSpaces=False):
         """
         Creates a PDF file with an image superimposed on top of the text.
         Text is positioned according to the bounding box of the lines in
@@ -196,6 +196,9 @@ class HocrTransform():
             if len(elemtxt) == 0:
                 continue
 
+            if interwordSpaces:
+                elemtxt += ' '
+
             pxl_coords = self.element_coordinates(elem)
             pt = self.pt_from_pixel(pxl_coords)
 
@@ -242,10 +245,12 @@ if __name__ == "__main__":
                         help='Resolution of the image that was OCRed')
     parser.add_argument('-i', '--image', default=None,
                         help='Path to the image to be placed above the text')
+    parser.add_argument('--interword-spaces', action='store_true',
+                         default=False, help='Add spaces between words')
     parser.add_argument('hocrfile', help='Path to the hocr file to be parsed')
     parser.add_argument(
         'outputfile', help='Path to the PDF file to be generated')
     args = parser.parse_args()
 
     hocr = HocrTransform(args.hocrfile, args.resolution)
-    hocr.to_pdf(args.outputfile, args.image, args.boundingboxes)
+    hocr.to_pdf(args.outputfile, args.image, args.boundingboxes, interwordSpaces=args.interword_spaces)

--- a/ocrmypdf/pipeline.py
+++ b/ocrmypdf/pipeline.py
@@ -639,8 +639,8 @@ def render_hocr_page(
 
     hocrtransform = HocrTransform(hocr, dpi)
     hocrtransform.to_pdf(output_file, imageFileName=None,
-                         showBoundingboxes=False, invisibleText=True)
-
+                         showBoundingboxes=False, invisibleText=True,
+                         interwordSpaces=options.interword_spaces)
 
 def flatten_groups(groups):
     for obj in groups:
@@ -664,8 +664,8 @@ def render_hocr_debug_page(
 
     hocrtransform = HocrTransform(hocr, dpi)
     hocrtransform.to_pdf(output_file, imageFileName=None,
-                         showBoundingboxes=True, invisibleText=False)
-
+                         showBoundingboxes=True, invisibleText=False,
+                         interwordSpaces=options.interword_spaces)
 
 def combine_layers(
         infiles,


### PR DESCRIPTION
This commit includes an optional work around for limitations of the
PDF.js viewer described in
https://github.com/jbarlow83/OCRmyPDF/issues/133. Here is explicitly
add an additional space to text elements before drawing them on the PDF
canvas when using the HOCR renderer. This option does not apply to
other pdf renderers in OCRmyPDF and is turned off by default.