### PR TITLE
remove addopts key from tool:pytest section of setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ ignore =
 [tool:pytest]
 norecursedirs = lib .pc .git output cache resources
 testpaths = tests
-addopts = -n auto
 
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
The '-n' command line argument is not supported by recent pytest, at least the version in Debian.  Thanks.