### PR TITLE
xfail tests that fail on BE archs?

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,6 +41,11 @@ check_ocrmypdf = pytest.helpers.check_ocrmypdf
 run_ocrmypdf = pytest.helpers.run_ocrmypdf
 spoof = pytest.helpers.spoof
 
+# Tesseract has issues on big endian architectures.  This should not
+# cause OCRmyPDF's test suite to fail because we are an
+# architecture-independent package.  See https://bugs.debian.org/849094
+bigendian = pytest.mark.xfail(sys.byteorder == 'big',
+                              reason="fails on BE archs due to a bug in Tesseract")
 
 RENDERERS = ['hocr', 'tesseract']
 if tesseract.has_textonly_pdf():
@@ -695,6 +700,7 @@ def test_destination_not_writable(spoof_tesseract_noop, resources, outdir):
     assert p.returncode == ExitCode.file_access_error, "Expected error"
 
 
+@bigendian
 def test_tesseract_config_valid(resources, outdir):
     cfg_file = outdir / 'test.cfg'
     with cfg_file.open('w') as f:
@@ -709,6 +715,7 @@ language_model_penalty_non_freq_dict_word 0
         '--tesseract-config', cfg_file)
 
 
+@bigendian
 @pytest.mark.parametrize('renderer', RENDERERS)
 def test_tesseract_config_notfound(renderer, resources, outdir):
     cfg_file = outdir / 'nofile.cfg'
@@ -737,6 +744,7 @@ THIS FILE IS INVALID
     assert p.returncode == ExitCode.invalid_config
 
 
+@bigendian
 def test_user_words(resources, outdir):
     word_list = outdir / 'wordlist.txt'
     sidecar_before = outdir / 'sidecar_before.txt'
@@ -774,6 +782,7 @@ def test_form_xobject(spoof_tesseract_noop, resources, outpdf):
                    env=spoof_tesseract_noop)
 
 
+@bigendian
 @pytest.mark.parametrize('renderer', RENDERERS)
 def test_pagesize_consistency(renderer, resources, outpdf):
     from math import isclose

--- a/tests/test_tess4.py
+++ b/tests/test_tess4.py
@@ -28,6 +28,11 @@ from pathlib import Path
 # pylint: disable=no-member
 spoof = pytest.helpers.spoof
 
+# Tesseract has issues on big endian architectures.  This should not
+# cause OCRmyPDF's test suite to fail because we are an
+# architecture-independent package.  See https://bugs.debian.org/849094
+bigendian = pytest.mark.xfail(sys.byteorder == 'big',
+                              reason="fails on BE archs due to a bug in Tesseract")
 
 @pytest.fixture
 def ensure_tess4():
@@ -83,6 +88,7 @@ run_ocrmypdf = pytest.helpers.run_ocrmypdf
 spoof = pytest.helpers.spoof
 
 
+@bigendian
 def test_textonly_pdf(ensure_tess4, resources, outdir):
     check_ocrmypdf(
         resources / 'linn.pdf',
@@ -91,6 +97,7 @@ def test_textonly_pdf(ensure_tess4, resources, outdir):
         env=ensure_tess4)
 
 
+@bigendian
 def test_pagesize_consistency_tess4(ensure_tess4, resources, outpdf):
     from math import isclose
 


### PR DESCRIPTION
This is a patch from @ginggs that xfails tests that are known to fail on big endian architectures.  It is currently being carried by Ubuntu, but not by Debian.  I would like to hear @jbarlow83's opinion on the patch.

On the one hand, these failures are due to a bug in Tesseract, and OCRmyPDF's test suite should not fail when the bug is in OCRmyPDF.

On the other hand, OCRmyPDF will not work properly on BE machines with a broken tesseract, and we might want OCRmyPDF's test suite to detect that situation and fail.

I am not sure which of these best reflect @jbarlow83's intentions for the test suite.  Let me know!