### PR TITLE
Updating Arch Linux instalation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -207,11 +207,15 @@ ArchLinux
     :alt: ArchLinux
     :target: https://repology.org/metapackage/ocrmypdf
 
-The author is aware of an `ArchLinux package for ocrmypdf <https://aur.archlinux.org/packages/ocrmypdf/>`_. It seems like the following command might work.
+The author is aware of an `ArchLinux User Repository package for ocrmypdf <https://aur.archlinux.org/packages/ocrmypdf/>`_. You can use the following command.
 
 .. code-block:: bash
 
-    pacman -S ocrmypdf
+    yaourt -S ocrmypdf
+
+It can crash on building pybind11 (for pikepdf), just edit the PKGBUILD:
+from: pybind11<3,>=2.2.3
+to: pybind11>=2.2.3
 
 Other Linux packages
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -213,9 +213,7 @@ The author is aware of an `ArchLinux User Repository package for ocrmypdf <https
 
     yaourt -S ocrmypdf
 
-It can crash on building pybind11 (for pikepdf), just edit the PKGBUILD:
-from: pybind11<3,>=2.2.3
-to: pybind11>=2.2.3
+If you have any difficulties with installation, check the repository package page.
 
 Other Linux packages
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
And adding a workaround to a wrong dependencies definition on https://aur.archlinux.org/packages/python-pikepdf/

ocrmypdf is not on the main arch linux repository it is on a user one, so it is not available through pacman and the user can install via yaourt to manage the aur packages. Maybe the user needs to install yaourt itself, but this is implicity.