### PR TITLE
Add Fedora install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Users of Debian 9 or later or Ubuntu 16.10 or later may simply
 apt-get install ocrmypdf
 ```
 
+and users of Fedora 29 or later may simply
+
+```bash
+dnf install ocrmypdf
+```
+
 and macOS users with Homebrew may simply
 
 ```bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -69,7 +69,7 @@ Fedora 29 or newer
 .. |fedora-29| image:: https://repology.org/badge/version-for-repo/fedora29/ocrmypdf.svg
     :alt: Fedora 29
 
-.. |fedora-rawhide| image:: https://repology.org/badge/version-for-repo/fedora-rawhide/ocrmypdf.svg
+.. |fedora-rawhide| image:: https://repology.org/badge/version-for-repo/fedora_rawhide/ocrmypdf.svg
     :alt: Fedore Rawhide
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,6 +63,45 @@ For full details on version availability for your platform, check the `Debian Pa
 
     OCRmyPDF for Debian and Ubuntu currently omit the JBIG2 encoder. OCRmyPDF works fine without it but will produce larger output files. If you build jbig2enc from source, ocrmypdf 7.0.0 and later will automatically detect it (specifically the ``jbig2`` binary) on the ``PATH``. To add JBIG2 encoding, see :ref:`jbig2`.
 
+Fedora 29 or newer
+^^^^^^^^^^^^^^^^^^
+
+.. |fedora-29| image:: https://repology.org/badge/version-for-repo/fedora29/ocrmypdf.svg
+    :alt: Fedora 29
+
+.. |fedora-rawhide| image:: https://repology.org/badge/version-for-repo/fedora-rawhide/ocrmypdf.svg
+    :alt: Fedore Rawhide
+
+
++------------------------------+
+| **OCRmyPDF version**         |
++------------------------------+
+| |latest|                     |
++------------------------------+
+| |fedora-29| |fedora-rawhide| |
++------------------------------+
+
+Users of Fedora 29 later may simply
+
+.. code-block:: bash
+
+    dnf install ocrmypdf
+
+For full details on version availability, check the `Fedora Package Tracker
+<https://apps.fedoraproject.org/packages/ocrmypdf>`_.
+
+If the version available for your platform is out of date, you could opt to
+install the latest version from source. See `Installing HEAD revision from
+sources`_.
+
+.. note::
+
+    OCRmyPDF for Fedora currently omits the JBIG2 encoder due to patent issues.
+    OCRmyPDF works fine without it but will produce larger output files. If you
+    build jbig2enc from source, ocrmypdf 7.0.0 and later will automatically
+    detect it on the ``PATH``. To add JBIG2 encoding, see `Installing the JBIG2
+    encoder`_.
+
 Installing the latest version on Ubuntu 18.04 LTS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -17,11 +17,26 @@ Debian and Ubuntu users
    # Display a list of all Tesseract language packs
    apt-cache search tesseract-ocr
 
-   # Debian/Ubuntu users
-   apt-get install tesseract-ocr-chi-sim  # Example: Install Chinese Simplified language back
-   
+   # Install Chinese Simplified language pack
+   apt-get install tesseract-ocr-chi-sim
+
 You can then pass the ``-l LANG`` argument to OCRmyPDF to give a hint as to what languages it should search for. Multiple
 languages can be requested using either ``-l eng+fre`` (English and French) or ``-l eng -l fre``.
+
+Fedora users
+------------
+
+.. code-block:: bash
+
+   # Display a list of all Tesseract language packs
+   dnf search tesseract
+
+   # Install Chinese Simplified language pack
+   dnf install tesseract-langpack-chi_sim
+
+You can then pass the ``-l LANG`` argument to OCRmyPDF to give a hint as to
+what languages it should search for. Multiple languages can be requested using
+either ``-l eng+fre`` (English and French) or ``-l eng -l fre``.
 
 macOS users
 -----------


### PR DESCRIPTION
OCRmyPDF will be available in Fedora 29+.