### PR TITLE
Adjust the docker pull command for webservice

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -399,7 +399,7 @@ Assuming you have a Docker engine running, you can download one of the three ava
         - ``docker pull jbarlow83/ocrmypdf-polyglot``
         - As above, with all available language packs.
     *   - ocrmypdf-webservice
-        - ``docker pull jbarlow83/ocrmypdf-polyglot``
+        - ``docker pull jbarlow83/ocrmypdf-webservice``
         - All language packs, and a simple HTTP wrapper allowing OCRmyPDF to be used as a web service. Note that this component is licensed under AGPLv3.
 
 For example:


### PR DESCRIPTION
Thanks, as ever, for the tremendous work and continuous improvements to ocrmypdf.  These installation options are terrific and I am starting to explore the docker image webservice which is a very interesting option.

Not completely sure this PR change is correct, but I think `docker pull jbarlow83/ocrmypdf-webservice` might be the intended command for getting the webservice version.  It installs as expected where the original suggests that polyglot is the docker image name for both of the last two options in the table:

```
docker pull jbarlow83/ocrmypdf-webservice
Using default tag: latest
latest: Pulling from jbarlow83/ocrmypdf-webservice
38e2e6cd5626: Already exists 
705054bc3f5b: Already exists 
c7051e069564: Already exists 
7308e914506c: Already exists 
3977c3cd82d1: Already exists 
ec01b9573956: Already exists 
b508b5192a3c: Already exists 
ace6e737fffb: Already exists 
0a453ee84e11: Already exists 
f8cb8b66151b: Already exists 
f53c3b27b23f: Already exists 
22df51ea5473: Already exists 
e38d932f9f30: Already exists 
b9d3c1d5b53b: Already exists 
68be2088ada3: Already exists 
8b17945ab41b: Pull complete 
59c4aae491bd: Pull complete 
19dce698a07e: Pull complete 
Digest: sha256:0cc9433d490c9a65389403757bf6081a30bcd248055340a8789c23d9cdf9ac8a
Status: Downloaded newer image for jbarlow83/ocrmypdf-webservice:latest
```