### PR TITLE
Catch AttributeError thrown when using OCRmyPDF in a Celery Job

### DIFF
--- a/src/ocrmypdf/leptonica.py
+++ b/src/ocrmypdf/leptonica.py
@@ -77,7 +77,7 @@ class _LeptonicaErrorTrap:
         try:
             self.copy_of_stderr = os.dup(sys.stderr.fileno())
             os.dup2(self.tmpfile.fileno(), sys.stderr.fileno(), inheritable=False)
-        except UnsupportedOperation:
+        except (UnsupportedOperation, AttributeError):
             self.copy_of_stderr = None
         return
 


### PR DESCRIPTION
When using OCRmyPDF in a Celery job the following exception is thrown: 

`AttributeError: 'LoggingProxy' object has no attribute 'fileno'`

Please refer to the following issue in Celery issue tracker for more info: [celery breaks libs using sys.stdout.fileno() or sys.stderr.fileno()](https://github.com/celery/celery/issues/928)

To fix this issue, I updated _LeptonicaErrorTrap.__enter__ function to also catch AttributeError.