### PR TITLE
Add bash completion

### DIFF
--- a/misc/ocrmypdf
+++ b/misc/ocrmypdf
@@ -1,0 +1,77 @@
+# ocrmypdf completion                                     -*- shell-script -*-
+
+_ocrmypdf()
+{
+    local cur prev split
+    _init_completion -s || return
+
+    case $prev in
+        --version|-h|--help)
+            return
+            ;;
+        --user-words|--user-patterns|--tesseract-config)
+            _filedir
+            return
+            ;;
+        --output-type)
+            COMPREPLY=( $( compgen -W 'pdfa pdf pdfa-1 pdfa-2 pdfa-3' -- \
+		"$cur" ) )
+            return
+            ;;
+        --pdf-renderer)
+            COMPREPLY=( $( compgen -W 'auto hocr sandwich' -- "$cur" ) )
+            return
+            ;;
+        --pdfa-image-compression)
+            COMPREPLY=( $( compgen -W 'auto jpeg lossless' -- "$cur" ) )
+            return
+            ;;
+        -O|--optimize|--tesseract-oem)
+            COMPREPLY=( $( compgen -W '{0..3}' -- "$cur" ) )
+            return
+            ;;
+        --jpeg-quality|--png-quality)
+            COMPREPLY=( $( compgen -W '{0..100}' -- "$cur" ) )
+            return
+            ;;
+        -l|--language)
+            COMPREPLY=$( command tesseract --list-langs 2>/dev/null )
+            COMPREPLY=( $( compgen -W '${COMPREPLY[@]##*:}' -- "$cur" ) )
+            return
+            ;;
+        --image-dpi|--oversample|--skip-big|--max-image-mpixels|\
+	--tesseract-timeout|--rotate-pages-threshold)
+            COMPREPLY=( $( compgen -P "$cur" -W '{0..9}' ) )
+            return
+            ;;
+         -j|--jobs)
+            COMPREPLY=( $( compgen -W '{1..'$( _ncpus )'}' -- "$cur" ) )
+            return
+            ;;
+        -v|--verbose)
+            COMPREPLY=( $( compgen -W '{1..9}' -- "$cur" ) ) # max level ?
+            return
+            ;;
+	--tesseract-pagesegmode)
+            COMPREPLY=( $( compgen -W '{1..13}' -- "$cur" ) )
+            return
+            ;;
+	--sidecar|--title|--author|--subject|--keywords|--unpaper-args)
+            # argument required but no completions available
+            return
+            ;;
+    esac
+
+    $split && return
+
+    if [[ $cur == -* ]]; then   # '$( _parse_help "$1" )' does not work
+        COMPREPLY=( $( compgen -W '$( _parse_help - <<< $( "$1" --help ) )' --\
+	    "$cur" ) )
+        return
+    else
+        _filedir
+        return
+    fi
+
+} &&
+complete -F _ocrmypdf ocrmypdf

--- a/misc/ocrmypdf
+++ b/misc/ocrmypdf
@@ -2,7 +2,7 @@
 
 _ocrmypdf()
 {
-    local cur prev split
+    local cur prev cword words split
     _init_completion -s || return
 
     case $prev in
@@ -15,7 +15,7 @@ _ocrmypdf()
             ;;
         --output-type)
             COMPREPLY=( $( compgen -W 'pdfa pdf pdfa-1 pdfa-2 pdfa-3' -- \
-		"$cur" ) )
+                "$cur" ) )
             return
             ;;
         --pdf-renderer)
@@ -40,11 +40,11 @@ _ocrmypdf()
             return
             ;;
         --image-dpi|--oversample|--skip-big|--max-image-mpixels|\
-	--tesseract-timeout|--rotate-pages-threshold)
+        --tesseract-timeout|--rotate-pages-threshold)
             COMPREPLY=( $( compgen -P "$cur" -W '{0..9}' ) )
             return
             ;;
-         -j|--jobs)
+        -j|--jobs)
             COMPREPLY=( $( compgen -W '{1..'$( _ncpus )'}' -- "$cur" ) )
             return
             ;;
@@ -52,11 +52,11 @@ _ocrmypdf()
             COMPREPLY=( $( compgen -W '{1..9}' -- "$cur" ) ) # max level ?
             return
             ;;
-	--tesseract-pagesegmode)
+        --tesseract-pagesegmode)
             COMPREPLY=( $( compgen -W '{1..13}' -- "$cur" ) )
             return
             ;;
-	--sidecar|--title|--author|--subject|--keywords|--unpaper-args)
+        --sidecar|--title|--author|--subject|--keywords|--unpaper-args)
             # argument required but no completions available
             return
             ;;
@@ -64,14 +64,24 @@ _ocrmypdf()
 
     $split && return
 
-    if [[ $cur == -* ]]; then   # '$( _parse_help "$1" )' does not work
-        COMPREPLY=( $( compgen -W '$( _parse_help - <<< $( "$1" --help ) )' --\
-	    "$cur" ) )
+    if [[ $cur == -* ]]; then
+        COMPREPLY=( $( compgen -W '--language --image-dpi --output-type
+            --sidecar --version --jobs --quiet --verbose --title --author
+            --subject --keywords --rotate-pages --remove-background --deskew
+            --clean --clean-final --unpaper-args --oversample --remove-vectors
+            --mask-barcodes --threshold --force-ocr --skip-text --redo-ocr
+            --skip-big --jpeg-quality --png-quality --jbig2-lossy
+            --max-image-mpixels --tesseract-config --tesseract-pagesegmode
+            --help --tesseract-oem --pdf-renderer --tesseract-timeout
+            --rotate-pages-threshold --pdfa-image-compression --user-words
+            --user-patterns --keep-temporary-files --flowchart --output-type' \
+            --  "$cur" ) )
         return
     else
         _filedir
         return
     fi
-
 } &&
 complete -F _ocrmypdf ocrmypdf
+
+# ex: filetype=sh


### PR DESCRIPTION
bash completion file for ocrmypdf
requires bash-completion installed https://github.com/scop/bash-completion
~~file must be copied to completion folder e.g. /usr/share/bash-completion/completions~~

Edit:
possible solution for this issue: #333

Just source the script after download:
`source /<yourDownloadPath>/ocrmypdf`
Now enter: `ocrmypdf --<Tab>`   

Or use this gitpod share: [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/f6215430-9f60-4555-a7a2-890193ba43c3)
`source completion/ocrmypdf`
Now enter: `ocrmypdf --<Tab>`   

For installation options refer to [scop/bash-completion](https://github.com/scop/bash-completion)