### PR TITLE
Watched folder bug fixes, new flags, and docs updates.

### DIFF
--- a/docs/batch.rst
+++ b/docs/batch.rst
@@ -210,6 +210,9 @@ be launched as follows:
         -v <path to files to convert>:/input \
         -v <path to store results>:/output \
         -e OCR_OUTPUT_DIRECTORY_YEAR_MONTH=1 \
+        -e OCR_ON_SUCCESS_DELETE=1 \
+        -e OCR_DESKEW=1 \
+        -e PYTHONUNBUFFERED=1 \
         -it --entrypoint python3 \
         jbarlow83/ocrmypdf \
         watcher.py
@@ -224,6 +227,9 @@ convert it to a OCRed PDF in ``/output/``. The parameters to this image are:
     "``-v <path to files to convert>:/input``", "Files placed in this location will be OCRed"
     "``-v <path to store results>:/output``", "This is where OCRed files will be stored"
     "``-e OCR_OUTPUT_DIRECTORY_YEAR_MONTH=1``", "This will place files in the output in {output}/{year}/{month}/{filename}"
+    "``-e OCR_ON_SUCCESS_DELETE=1``", "This will delete the input file if the exit code is 0 (OK)"
+    "``-e OCR_DESKEW=1``", "This will enable deskew for crooked PDFs"
+    "``-e PYTHONBUFFERED=1``", "This will force STDOUT to be unbuffered and allow you to see messages in docker logs"
 
 This service relies on polling to check for changes to the filesystem. It
 may not be suitable for some environments, such as filesystems shared on a


### PR DESCRIPTION
This pull request is a followup to #466.

This PR fixes 2 bugs in `watcher.py` and adds additional functionality.

Bug fixes:

1. `Fix double-fire on create and modify events`: the `HandleObserverEvent` fires on both `create` and `modified` events. Depending on how the file is written to disk, this may cause 2 events to be fired, OCR'ing the PDF twice. This fix listens only for the `create` event and only fires once.
2. `Fix FileInput error when reading from docker volume`: Non-deterministicly, watchdog may fire a `create` even when a file is not fully written to disk on a docker volume. We fix this by watching the file size every second and waiting for new data to stop being written to disk. This solution works 100% reliabily my testing, both docker and non-docker.

New functonality: 

1. `ON_SUCCESS_DELETE`: Added a flag to delete the input file when ocrmypdf returns with a 0 (success) error code
2. `DESKEW`: Added a flag to enable or disable DESKEW
3. `Docs update with PYTHONBUFFERED`: By default, python3 buffers output to STDOUT. This prevents us from seeing what `watcher.py` is doing in the docker logs. I added an explaination to the docs that show how to enable this and see the python output in the logs.