### PR TITLE
Create a watcher based on shell script

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   pngquant \
   python3 \
   qpdf \
+  inotify-tools \
   tesseract-ocr \
   tesseract-ocr-chi-sim \
   tesseract-ocr-deu \
@@ -71,6 +72,7 @@ COPY --from=builder /usr/local/bin/ /usr/local/bin/
 
 COPY --from=builder /app/misc/webservice.py /app/
 COPY --from=builder /app/misc/watcher.py /app/
+COPY --from=builder /app/misc/watcher /app/
 
 # Copy minimal project files to get the test suite.
 COPY --from=builder /app/setup.cfg /app/setup.py /app/README.md /app/

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -168,3 +168,17 @@ also licensed in this way.
 
 In addition to the above, please read our
 :ref:`general remarks on using OCRmyPDF as a service <ocr-service>`.
+
+Using OCRmyPDF for automatic file conversion
+============================================
+
+The OCRmyPDF Docker image includes a script to automatically OCR files put
+into an input directory. The watcher script is started as follows:
+
+.. code-block:: bash
+
+   docker run --name ocrwatcher --entrypoint ./watcher -v $PWD/input:/input -v $PWD/output:/output jbarlow83/ocrmypdf <watcher-options> -- <ocrmypdf-options>
+
+where ``<watcher-options>`` may optionally include ``-r`` to remove correctly
+processed input files from input folder, and after the two hyphens all command
+line options for OCRmyPDF can be included.

--- a/misc/watcher
+++ b/misc/watcher
@@ -44,14 +44,19 @@ outfilename() {
 	if [ -e "$OUTFILE" ]; then
 		name="${1%.*}"
 		ext="${1##*.}"
+		NUM=$(ls "$name"* | wc -l)
 		OUTFILE="$name".$NUM.$ext
 	fi
 }
 
-while true
-do 
-	F=$(inotifywait -e CLOSE_WRITE -q "$INPUTDIR" --format %f)
-	outfilename "$OUTPUTDIR/$F"
+convert_infile()
+{
+	outfilename "$OUTPUTDIR/$1"
 
 	ocrmypdf $OCRMYPDFOPTS "$INPUTDIR/$F" "$OUTFILE" && $REMOVEONSUCCESS "$INPUTDIR/$F"
-done
+}
+
+inotifywait -m -e CLOSE_WRITE -q "$INPUTDIR" --format %f |
+	while read F; do
+		  convert_infile $F
+	done

--- a/misc/watcher
+++ b/misc/watcher
@@ -39,8 +39,19 @@ shift $((OPTIND-1))
 
 OCRMYPDFOPTS="$*"
 
+outfilename() {
+	OUTFILE="$1"
+	if [ -e "$OUTFILE" ]; then
+		name="${1%.*}"
+		ext="${1##*.}"
+		OUTFILE="$name".$NUM.$ext
+	fi
+}
+
 while true
 do 
 	F=$(inotifywait -e CLOSE_WRITE -q "$INPUTDIR" --format %f)
-	ocrmypdf $OCRMYPDFOPTS "$INPUTDIR/$F" "$OUTPUTDIR/$F" && $REMOVEONSUCCESS "$INPUTDIR/$F"
-done 
+	outfilename "$OUTPUTDIR/$F"
+
+	ocrmypdf $OCRMYPDFOPTS "$INPUTDIR/$F" "$OUTFILE" && $REMOVEONSUCCESS "$INPUTDIR/$F"
+done

--- a/misc/watcher
+++ b/misc/watcher
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+usage() {
+	cat <<EOF 1>&2
+Usage: $0 [-i <inputdir>] [-o <outputdir>] [-r] [-- ocroptions]"
+Automatically OCRmyPDF files in input directory and put the result into
+output directory. Specify the options for OCRmyPDF after the double
+hyphen (--).
+
+Arguments:
+	   -i: Input directory
+	   -o: Output directory
+	   -r: Remove input file on successful conversion
+EOF
+		  exit 1;
+		}
+
+INPUTDIR=/input
+OUTPUTDIR=/output
+REMOVEONSUCCESS=true
+
+while getopts ":i:o:hr" o; do
+	case "${o}" in
+		i)
+			INPUTDIR="${OPTARG}"
+			;;
+		o)
+			OUTPUTDIR="${OPTARG}"
+			;;
+		r)
+			REMOVEONSUCCESS=rm
+			;;
+		h)
+			usage
+			;;
+	esac
+done
+shift $((OPTIND-1))
+
+OCRMYPDFOPTS="$*"
+
+while true
+do 
+	F=$(inotifywait -e CLOSE_WRITE -q "$INPUTDIR" --format %f)
+	ocrmypdf $OCRMYPDFOPTS "$INPUTDIR/$F" "$OUTPUTDIR/$F" && $REMOVEONSUCCESS "$INPUTDIR/$F"
+done 


### PR DESCRIPTION
To overcome some shortcomings as discussed in pull request #479, I created a minimal shell script based on `inotifywait` tool. The advantage is the inotify event `CLOSE_WRITE`, which is exactly the event OCRmyPDF should run after IMHO. Also, it is easy to include all command line options for OCRmyPDF, since it is called directly from the shell script.