### PR TITLE
Update installation instructions for FreeBSD

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -435,12 +435,12 @@ Installing on FreeBSD
     :alt: FreeBSD
     :target: https://repology.org/project/python:ocrmypdf/versions
 
-FreeBSD 11.2, 11.3, 12.0-RELEASE and 13.0-CURRENT are supported. Other
+FreeBSD 11.3, 12.0, 12.1-RELEASE and 13.0-CURRENT are supported. Other
 versions likely work but have not been tested.
 
 .. code-block:: bash
 
-    pkg install py36-ocrmypdf
+    pkg install py37-ocrmypdf
 
 To install a more recent version, you could attempt to first install the system
 version with ``pkg``, then use ``pip install --user ocrmypdf``.


### PR DESCRIPTION
Python 3.7 is the new default version since 2020Q1 which is reflected in
the new prefix (= py37-).

Also update the current available FreeBSD versions:

* FreeBSD 11.2-RELEASE has reached its End-of-Life in 2019Q4
* FreeBSD 12.1-RELEASE was also introduced in 2019Q4