### PR TITLE
fix install instructions for Ubunti 16.04

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -232,7 +232,7 @@ environment variable contains ``$HOME/.local/bin``.
 .. code-block:: bash
 
     export PATH=$HOME/.local/bin:$PATH
-    pip3 install --user ocrmypdf
+    pip3.6 install --user ocrmypdf
 
 To add JBIG2 encoding, see :ref:`jbig2`.
 


### PR DESCRIPTION
`pip3` defaults to the system's outdated version which downloads wrong qpdf package.