### PR TITLE
Watcher.py write output with more open permissions

### DIFF
--- a/misc/watcher.py
+++ b/misc/watcher.py
@@ -96,6 +96,7 @@ def execute_ocrmypdf(file_path):
         **OCR_JSON_SETTINGS,
     )
     if exit_code == 0 and ON_SUCCESS_DELETE:
+        os.chmod(output_path, 0o664)
         log.info(f'OCR is done. Deleting: {file_path}')
         file_path.unlink()
     else:


### PR DESCRIPTION
If the OCR is successful, change the pdf output to use 664 permissions.
It will then be writeable by owner/group and readable by all.

Means that the resulting file is not just read/write by root in the docker
container.