### PR TITLE
Enable build for aarch64 in Dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -11,10 +11,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libleptonica-dev \
   zlib1g-dev \
   python3 \
+  python3-dev \
+  libssl-dev \
+  libffi-dev \
+  libjpeg-dev \
+  zlib1g-dev \
+  libqpdf-dev \
+  pybind11-dev \
+  libxml2-dev \ 
+  libxslt1-dev \
   python3-distutils \
   ca-certificates \
   curl \
-  git
+  git 
 
 # Get the latest pip (Ubuntu version doesn't support manylinux2010)
 RUN \
@@ -52,6 +61,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   liblept5 \
   libsm6 libxext6 libxrender-dev \
   zlib1g \
+  libxslt-dev \
   pngquant \
   python3 \
   qpdf \
@@ -62,7 +72,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   tesseract-ocr-fra \
   tesseract-ocr-por \
   tesseract-ocr-spa \
-  unpaper
+  unpaper \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/.github/workflows/buildx-latest.yml
+++ b/.github/workflows/buildx-latest.yml
@@ -1,0 +1,36 @@
+name: Build and Push Dockerhub
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - .github/**
+      - README.md
+  release:
+    types: [published]
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Image Tag to Release or Branch
+        run: echo "::set-env name=DOCKER_IMAGE_TAG::${GITHUB_REF##*/}"
+      - name: If master, set to latest
+        run: echo '::set-env name=DOCKER_IMAGE_TAG::latest'
+        if: env.DOCKER_IMAGE_TAG == 'master'
+      - name: Set Docker Hub Repository to username
+        run: echo "::set-env name=DOCKER_REPOSITORY::${{ secrets.DOCKERHUB_USERNAME }}"
+      - name: Set Image Name 
+        run: echo "::set-env name=DOCKER_IMAGE_NAME::${{ secrets.DOCKERHUB_IMAGE_NAME }}"
+      - uses: actions/checkout@v2
+      - name: Buildx setup
+        uses: crazy-max/ghaction-docker-buildx@v2
+      - name: Dockerhub login
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin 2>&1
+      - name: Print Image Tag
+        run: echo "Building Image ${DOCKER_REPOSITORY}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+      - name: Run Buildx
+        run: |
+          docker buildx build \
+            --push \
+            --platform linux/arm64/v8,linux/amd64  \
+            --tag "${DOCKER_REPOSITORY}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" \
+            --file .docker/Dockerfile .


### PR DESCRIPTION
This PR contains an "enhanced" version of the original Dockerfile that enables you to build cross-platform images for both amd64 and aarch64 with buildx. Sample command is below.

`docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag jbarlow83/ocrmypdf:latest --file .docker/Dockerfile .`

I will also try to work on a matching action to automate build upon merge.