### PR TITLE
Update _pipeline.py

### DIFF
--- a/src/ocrmypdf/_pipeline.py
+++ b/src/ocrmypdf/_pipeline.py
@@ -813,7 +813,10 @@ def copy_final(input_file, output_file, _context: PdfContext):
     log.debug('%s -> %s', input_file, output_file)
     with open(input_file, 'rb') as input_stream:
         if output_file == '-':
-            copyfileobj(input_stream, sys.stdout.buffer)
+            try:
+                copyfileobj(input_stream, sys.stdout.buffer)
+            except AttributeError:
+                copyfileobj(input_stream, sys.stdout)
             sys.stdout.flush()
         elif hasattr(output_file, 'writable'):
             output_stream = output_file


### PR DESCRIPTION
Updated to fix known issue of ipython and ijupyter stream objects not having a buffer attribute, but accepting either bytes or str.