### PR TITLE
Fix: except pikepdf._qpdf.ForeignObjectError

### DIFF
--- a/src/ocrmypdf/helpers.py
+++ b/src/ocrmypdf/helpers.py
@@ -191,6 +191,8 @@ def check_pdf(input_file: Path) -> bool:
             pdf.check_linearization(sio)
         except RuntimeError:
             pass
+        except pikepdf._qpdf.ForeignObjectError:
+            pass
         else:
             linearize = sio.getvalue()
             if linearize:


### PR DESCRIPTION
This fixes #680 by excepting `pikepdf._qpdf.ForeignObjectError`.

An alternative fix would be to not check linearization: #682 