### PR TITLE
docs: fix simple typo, instsalled -> installed

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -637,7 +637,7 @@ Installing with Python pip
 OCRmyPDF is delivered by PyPI because it is a convenient way to install
 the latest version. However, PyPI and ``pip`` cannot address the fact
 that ``ocrmypdf`` depends on certain non-Python system libraries and
-programs being instsalled.
+programs being installed.
 
 For best results, first install `your platform's
 version <https://repology.org/metapackage/ocrmypdf/versions>`__ of


### PR DESCRIPTION
There is a small typo in docs/installation.rst.

Should read `installed` rather than `instsalled`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md