### PR TITLE
Allow --sidecar along --pages

### DIFF
--- a/src/ocrmypdf/_validation.py
+++ b/src/ocrmypdf/_validation.py
@@ -184,8 +184,6 @@ def check_options_ocr_behavior(options):
     )
     if exclusive_options >= 2:
         raise BadArgsError("Choose only one of --force-ocr, --skip-text, --redo-ocr.")
-    if options.pages and options.sidecar:
-        raise BadArgsError("--pages and --sidecar are mutually exclusive")
     if options.pages:
         options.pages = _pages_from_ranges(options.pages)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -61,3 +61,90 @@ def test_dpi_needed(image, text, vector, result, rgb_image, outdir):
 
     assert _pipeline.get_canvas_square_dpi(pi[0], mock) == result
     assert _pipeline.get_page_square_dpi(pi[0], mock) == result
+
+
+@pytest.mark.parametrize(
+    # Name for nicer -v output
+    'name,input,output',
+    (
+        (
+            'empty_input',
+            # Input:
+            (),
+            # Output:
+            (),
+        ),
+        (
+            'no_values',
+            # Input:
+            ('', '', '', '', ''),
+            # Output:
+            (
+                ((1, 5), None),
+            ),
+        ),
+        (
+            'no_empty_values',
+            # Input:
+            ('v', 'w', 'x', 'y', 'z'),
+            # Output:
+            (
+                ((1, 1), 'v'),
+                ((2, 2), 'w'),
+                ((3, 3), 'x'),
+                ((4, 4), 'y'),
+                ((5, 5), 'z'),
+            ),
+        ),
+        (
+            'skip_head',
+            # Input:
+            ('', '', 'x', 'y', 'z'),
+            # Output:
+            (
+                ((1, 2), None),
+                ((3, 3), 'x'),
+                ((4, 4), 'y'),
+                ((5, 5), 'z'),
+            ),
+        ),
+        (
+            'skip_tail',
+            # Input:
+            ('x', 'y', 'z', '', ''),
+            # Output:
+            (
+                ((1, 1), 'x'),
+                ((2, 2), 'y'),
+                ((3, 3), 'z'),
+                ((4, 5), None),
+            ),
+        ),
+        (
+            'range_in_middle',
+            # Input:
+            ('x', '', '', '', 'y'),
+            # Output:
+            (
+                ((1, 1), 'x'),
+                ((2, 4), None),
+                ((5, 5), 'y'),
+            ),
+        ),
+        (
+            'range_in_middle_2',
+            # Input:
+            ('x', '', '', 'y', '', '', '', 'z'),
+            # Output:
+            (
+                ((1, 1), 'x'),
+                ((2, 3), None),
+                ((4, 4), 'y'),
+                ((5, 7), None),
+                ((8, 8), 'z'),
+            ),
+        ),
+    ),
+)
+def test_enumerate_compress_ranges(name, input, output):
+    assert output == tuple(_pipeline.enumerate_compress_ranges(input))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -90,8 +90,6 @@ def test_mutex_options():
         vd.check_options_ocr_behavior(make_opts(redo_ocr=True, skip_text=True))
     with pytest.raises(BadArgsError):
         vd.check_options_ocr_behavior(make_opts(redo_ocr=True, force_ocr=True))
-    with pytest.raises(BadArgsError):
-        vd.check_options_ocr_behavior(make_opts(pages='1-3', sidecar='file.txt'))
 
 
 def test_optimizing(caplog):


### PR DESCRIPTION
After a few short checks it looks like --sidecar and --pages can work together and produce reasonable results.
This PR relaxes this constraint and prints skipped pages as ranges.