### PR TITLE
Updated documentation for windows and additional languages

### DIFF
--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -70,4 +70,4 @@ derived Docker image as
 Windows users
 =============
 
-The Tesseract installer provided by Chocolatey includes only language. To install other languages, please download the respective language pack (.traineddata file) from https://github.com/tesseract-ocr/tessdata/ and place it in `C:\\Program Files\\Tesseract-OCR\\tessdata`.
+The Tesseract installer provided by Chocolatey currently includes only english language. To install other languages, please download the respective language pack (.traineddata file) from https://github.com/tesseract-ocr/tessdata/ and place it in `C:\\Program Files\\Tesseract-OCR\\tessdata`.

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -70,4 +70,4 @@ derived Docker image as
 Windows users
 =============
 
-The Tesseract installer provided by Chocolatey already includes 100 languages.
+The Tesseract installer provided by Chocolatey includes only language. To install other languages, please download the respective language pack (.traineddata file) from https://github.com/tesseract-ocr/tessdata/ and place it in `C:\\Program Files\\Tesseract-OCR\\tessdata`.

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -70,4 +70,7 @@ derived Docker image as
 Windows users
 =============
 
-The Tesseract installer provided by Chocolatey currently includes only english language. To install other languages, please download the respective language pack (.traineddata file) from https://github.com/tesseract-ocr/tessdata/ and place it in `C:\\Program Files\\Tesseract-OCR\\tessdata`.
+The Tesseract installer provided by Chocolatey currently includes only English language. 
+To install other languages, download the respective language pack (``.traineddata`` file) 
+from https://github.com/tesseract-ocr/tessdata/ and place it in 
+``C:\\Program Files\\Tesseract-OCR\\tessdata`` (or wherever Tesseract OCR is installed).


### PR DESCRIPTION
Just installed ocrmypdf on windows and found that there are no additional languages installed. So I changed the documentation how to add new languages on windows.