### PR TITLE
Update the FreeBSD specific parts of the documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ These platforms have one-liner installs:
 +-------------------------------+-------------------------------+
 | LinuxBrew                     | ``brew install ocrmypdf``     |
 +-------------------------------+-------------------------------+
-| FreeBSD                       | ``pkg install py37-ocrmypdf`` |
+| FreeBSD                       | ``pkg install py38-ocrmypdf`` |
 +-------------------------------+-------------------------------+
 | Conda (WSL, macOS, Linux)     | ``conda install ocrmypdf``    |
 +-------------------------------+-------------------------------+
@@ -635,7 +635,7 @@ versions likely work but have not been tested.
 
 .. code-block:: bash
 
-    pkg install py37-ocrmypdf
+    pkg install py38-ocrmypdf
 
 To install a more recent version, you could attempt to first install the system
 version with ``pkg``, then use ``pip install --user ocrmypdf``.


### PR DESCRIPTION
The Python default version was changed from 3.7 to 3.8 at the end of April.  For the new quarterly branch, 2021Q3, Python 3.8 has also been the default version since July.