### PR TITLE
Allow watchdog 2.

### DIFF
--- a/misc/watcher.py
+++ b/misc/watcher.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (C) 2019 Ian Alexander: https://github.com/ianalexander
 # Copyright (C) 2020 James R Barlow: https://github.com/jbarlow83
 #

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ docs =
 extended_test =
     PyMuPDF == 1.13.4
 watcher =
-    watchdog >= 1.0.2, < 2
+    watchdog >= 1.0.2, < 3
 webservice =
     Flask >= 1, < 2
 


### PR DESCRIPTION
The breaking change was dropping support for macOS 10.12 and earlier, which doesn't affect us.