### PR TITLE
Allow flask 2 for webservice

### DIFF
--- a/misc/webservice.py
+++ b/misc/webservice.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # webservice.py wrapper for OCRmyPDF
 # Copyright (C) 2019 James R. Barlow: github.com/jbarlow83
 #

--- a/misc/webservice.py
+++ b/misc/webservice.py
@@ -36,7 +36,6 @@ from flask import (
     redirect,
     request,
     send_from_directory,
-    url_for,
 )
 from werkzeug.utils import secure_filename
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,7 @@ extended_test =
 watcher =
     watchdog >= 1.0.2, < 2
 webservice =
-    Flask >= 1, < 2
+    Flask >= 1, < 3
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
There are breaking changes, but it seems like it doesn't break anything to use it.