### PR TITLE
[ci skip] docs/conf.py: add intersphinx mapping to make external links work

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
 ]
 
 # Extension settings
+intersphinx_mapping = {'https://docs.python.org/': None}
 napoleon_use_rtype = False
 issues_github_path = "jbarlow83/OCRmyPDF"
 


### PR DESCRIPTION
This polishes the fix for #837 and maybe makes it possible to reference ocrmypdf with intersphinx, which currently doesn't seem to work.