### PR TITLE
ghostscript: force interpolation when rendering

### DIFF
--- a/src/ocrmypdf/_exec/ghostscript.py
+++ b/src/ocrmypdf/_exec/ghostscript.py
@@ -95,6 +95,7 @@ def rasterize_pdf(
             '-dSAFER',
             '-dBATCH',
             '-dNOPAUSE',
+            '-dInterpolateControl=-1',
             f'-sDEVICE={raster_device}',
             f'-dFirstPage={pageno}',
             f'-dLastPage={pageno}',


### PR DESCRIPTION
Specifying option --oversample tends to introduce upsampling in rendering
by rasterizing page to an higher DPI.

This upsampling improves OCR results, but a correct choice of interpolation
method can increase even more the OCR quality.

Ghostscript seems to use a nearest interpolation as default choice for pdf.
This method doesn't average new introduced pixels with original pixels
resulting in an almost similar image but with more pixels.

Providing -dInterpolateControl=-1 force switching interpolation on.

In this commit the above option is passed to all ghostscript rendering
calls.

After testing, rendering a page at same DPI with interpolation
enabled does not introduce significant time overhead.

time (repeat 40 gs -dQUIET -dSAFER -dBATCH -dNOPAUSE -sDEVICE=png16m \
	-dFirstPage=1 -dLastPage=1 -r100.000000x100.000000 \
	-dInterpolateControl=-1 -o /dev/null -dAutoRotatePages=/None -f pzII.pdf)
7,66s user 0,33s system 99% cpu 8,012 total

time (repeat 40 gs -dQUIET -dSAFER -dBATCH -dNOPAUSE -sDEVICE=png16m \
	-dFirstPage=1 -dLastPage=1 -r100.000000x100.000000 \
        -o /dev/null -dAutoRotatePages=/None -f pzII.pdf)
7,42s user 0,39s system 99% cpu 7,808 total

Ghostscript interpolation control reference:
https://www.ghostscript.com/doc/current/Use.htm

With a page of 100dpi oversampled to 600dpi, sample of 500x500 from rendered image:

| Stage | Original 100dpi | Upsampled 600dpi (nearest) | Upsampled 600dpi (interpolated) |
| -------- | ----------- | --------------------- | ------------------------- |
Rendering (ghostscript) | ![pzII_100dpi_sample](https://user-images.githubusercontent.com/8046004/141311372-1c717a85-319e-4ef1-b449-4bacfe1dbd58.png) | ![pzII_600dpi_sample](https://user-images.githubusercontent.com/8046004/141305082-28966453-e8de-4cfc-923f-90214f37de3e.png) | ![pzII_600dpi_interpolated_sample](https://user-images.githubusercontent.com/8046004/141305081-685c8c2d-4af6-442e-bd14-173d8183f5dc.png)
Tesseract binarization (default OTSU, option `-c tessedit_write_images=1`) | ![pzII_100dpi_binarized_sample](https://user-images.githubusercontent.com/8046004/141311663-d5b017dd-d215-4fa5-a877-f4ceb050ea27.png) | ![pzII_600dpi_binarized_sample](https://user-images.githubusercontent.com/8046004/141311715-6357cd00-e25d-4b81-a134-58ba31f602db.png) | ![pzII_600dpi_interpolated_binarized_sample](https://user-images.githubusercontent.com/8046004/141311735-5d9f3c4f-b76a-48fe-abd4-0e3e9e7e738f.png)

P.S. It's my first PR in this project, let me know if I missed something and thanks a lot for your amazing work on the project !
